### PR TITLE
Add runtime support for Python 3.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Version 2.0.0 of `pytile` makes several breaking, but necessary changes:
 If you wish to continue using the previous, synchronous version of `pytile`,
 make sure to pin version 1.1.0.
 
+# Python Versions
+
+`pytile` is currently supported on:
+
+* Python 3.5
+* Python 3.6
+* Python 3.7
+
+However, running the test suite currently requires Python 3.6 or higher; tests
+run on Python 3.5 will fail.
+
 # Installation
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ DESCRIPTION = 'A simple Python API for Tile® Bluetooth trackers'
 URL = 'https://github.com/bachya/pytile'
 EMAIL = 'bachya1208@gmail.com'
 AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.6.0'
+REQUIRES_PYTHON = '>=3.5.3'
 VERSION = None
 
 # What packages are required for this module to be executed?
@@ -118,6 +118,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds runtime support for Python 3.5. Note that tests need Python 3.6+ to run.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)