### PR TITLE
Make typing a Makefile command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,5 @@ publish:
 	rm -rf dist/ build/ .egg pytile.egg-info/
 test:
 	pipenv run py.test
+typing:
+	pipenv run mypy --ignore-missing-imports pytile

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,4 @@ whitelist_externals = make
 deps = pipenv
 commands=
     make init
-    pipenv run mypy --ignore-missing-imports pytile
+    make typing


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes `typing` a Makefile argument.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
