### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/pytile/tile.py
+++ b/pytile/tile.py
@@ -1,25 +1,33 @@
 """Define endpoints for interacting with Tiles."""
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, List, Optional
+from uuid import UUID
 
 
 class Tile:  # pylint: disable=too-few-public-methods
     """Define "Tile" endpoints."""
 
-    def __init__(self, request: Callable[..., Awaitable[dict]], user_uuid: str) -> None:
+    def __init__(
+        self,
+        request: Callable[..., Awaitable[dict]],
+        *,
+        user_uuid: Optional[UUID] = None,
+    ) -> None:
         """Initialize."""
-        self._request = request
-        self._user_uuid = user_uuid
+        self._request: Callable[..., Awaitable[dict]] = request
+        self._user_uuid: Optional[UUID] = user_uuid
 
     async def all(self, whitelist: list = None, show_inactive: bool = False) -> list:
         """Get all Tiles for a user's account."""
-        list_data = await self._request("get", f"users/{self._user_uuid}/user_tiles")
-        tile_uuid_list = [
+        list_data: dict = await self._request(
+            "get", f"users/{self._user_uuid}/user_tiles"
+        )
+        tile_uuid_list: List[UUID] = [
             tile["tile_uuid"]
             for tile in list_data["result"]
             if not whitelist or tile["tileType"] in whitelist
         ]
 
-        tile_data = await self._request(
+        tile_data: dict = await self._request(
             "get", "tiles", params=[("tile_uuids", uuid) for uuid in tile_uuid_list]
         )
         return [

--- a/pytile/util.py
+++ b/pytile/util.py
@@ -2,6 +2,6 @@
 from time import time
 
 
-def current_epoch_time():
+def current_epoch_time() -> int:
     """Return the number of milliseconds since the Epoch."""
     return int(time() * 1000)


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
