### PR TITLE
Fix serialization issue with UUID header

### DIFF
--- a/pytile/client.py
+++ b/pytile/client.py
@@ -85,7 +85,7 @@ class Client:  # pylint: disable=too-many-instance-attributes
             {
                 "Tile_app_id": DEFAULT_APP_ID,
                 "Tile_app_version": DEFAULT_APP_VERSION,
-                "Tile_client_uuid": self.client_uuid,
+                "Tile_client_uuid": str(self.client_uuid),
             }
         )
 


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/pytile/pull/11 introduced an error whereby `aiohttp` wouldn't be able to deserialize a UUID header; this PR fixes that.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pytile/issues/13
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
