### PR TITLE
Simplify client creation and login process

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ async def main() -> None:
 asyncio.get_event_loop().run_until_complete(main())
 ```
 
-If you receive SSL errors, use `ClientSession(connector=TCPConnector(verify_ssl=False))
+If you receive SSL errors, use `ClientSession(connector=TCPConnector(verify_ssl=False))`
 instead.
 
 Create a client, initialize it, and get to work:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pip install pytile
 # Usage
 
 `pytile` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession` (if you are receiving SSL errors, use `ClientSession(connector=TCPConnector(verify_ssl=False))` instead):
+[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession:
 
 
 ```python
@@ -64,6 +64,9 @@ async def main() -> None:
 asyncio.get_event_loop().run_until_complete(main())
 ```
 
+If you receive SSL errors, use `ClientSession(connector=TCPConnector(verify_ssl=False))
+instead.
+
 Create a client, initialize it, and get to work:
 
 ```python
@@ -71,17 +74,42 @@ import asyncio
 
 from aiohttp import ClientSession
 
-from pytile import Client
+from pytile import login
 
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     async with ClientSession() as websession:
-    client = Client("<EMAIL>", "<PASSWORD>", websession)
-    await client.async_init()
+        client = await login("<EMAIL>", "<PASSWORD>", websession)
 
-    # Get all Tiles associated with an account:
-    await client.tiles.all()
+        # Get all Tiles associated with an account:
+        await client.tiles.all()
+
+
+asyncio.get_event_loop().run_until_complete(main())
+```
+
+If for some reason you need to use a specific client UUID (to, say, ensure that the
+Tile API sees you as a client it's seen before) or a specific locale, you can do
+so easily:
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from pytile import login
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    async with ClientSession() as websession:
+        client = await login(
+            "<EMAIL>", "<PASSWORD>", websession, client_uuid="MY_UUID", locale="en-GB"
+        )
+
+        # Get all Tiles associated with an account:
+        await client.tiles.all()
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ from pytile import Client
 async def main() -> None:
     """Create the aiohttp session and run the example."""
     async with ClientSession() as websession:
-      # YOUR CODE HERE
+        # YOUR CODE HERE
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/README.md
+++ b/README.md
@@ -15,19 +15,6 @@ location and more).
 This library is built on an unpublished, unofficial Tile API; it may alter or
 cease operation at any point.
 
-# PLEASE READ: Version 2.0.0 and Beyond
-
-Version 2.0.0 of `pytile` makes several breaking, but necessary changes:
-
-* Moves the underlying library from
-  [Requests](http://docs.python-requests.org/en/master/) to
-  [aiohttp](https://aiohttp.readthedocs.io/en/stable/)
-* Changes the entire library to use `asyncio`
-* Makes 3.6 the minimum version of Python required
-
-If you wish to continue using the previous, synchronous version of `pytile`,
-make sure to pin version 1.1.0.
-
 # Python Versions
 
 `pytile` is currently supported on:

--- a/example.py
+++ b/example.py
@@ -3,7 +3,7 @@ import asyncio
 
 from aiohttp import ClientSession
 
-from pytile import Client
+from pytile import login
 from pytile.errors import TileError
 
 
@@ -12,8 +12,7 @@ async def main():
     async with ClientSession() as websession:
         try:
             # Create a client:
-            client = Client("<EMAIL>", "<PASSWORD>", websession)
-            await client.async_init()
+            client = await login("<EMAIL>", "<PASSWORD>", websession)
 
             print("Showing active Tiles:")
             print(await client.tiles.all())

--- a/pytile/__init__.py
+++ b/pytile/__init__.py
@@ -1,2 +1,2 @@
 """Define module-level imports."""
-from .client import Client  # noqa
+from .client import login  # noqa

--- a/pytile/__init__.py
+++ b/pytile/__init__.py
@@ -1,2 +1,2 @@
 """Define module-level imports."""
-from .client import login  # noqa
+from .client import async_login  # noqa

--- a/pytile/client.py
+++ b/pytile/client.py
@@ -14,7 +14,7 @@ DEFAULT_APP_VERSION: str = "2.31.0"
 DEFAULT_LOCALE: str = "en-US"
 
 
-class Client:  # pylint: disable=too-many-instance-attributes
+class Client:  # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """Define the client."""
 
     def __init__(
@@ -36,37 +36,13 @@ class Client:  # pylint: disable=too-many-instance-attributes
         self.tiles: Optional[Tile] = None
         self.user_uuid: Optional[UUID] = None
 
-        self.client_uuid: Optional[UUID] = client_uuid
-        if not self.client_uuid:
+        self.client_uuid: UUID
+        if not client_uuid:
             self.client_uuid = uuid4()
+        else:
+            self.client_uuid = client_uuid
 
-    async def async_init(self) -> None:
-        """Create a Tile session."""
-        if not self._client_established:
-            await self.request(
-                "put",
-                f"clients/{self.client_uuid}",
-                data={
-                    "app_id": DEFAULT_APP_ID,
-                    "app_version": DEFAULT_APP_VERSION,
-                    "locale": self._locale,
-                },
-            )
-            self._client_established = True
-
-        resp: dict = await self.request(
-            "post",
-            f"clients/{self.client_uuid}/sessions",
-            data={"email": self._email, "password": self._password},
-        )
-
-        if not self.user_uuid:
-            self.user_uuid = resp["result"]["user"]["user_uuid"]
-        self._session_expiry = resp["result"]["session_expiration_timestamp"]
-
-        self.tiles = Tile(self.request, user_uuid=self.user_uuid)
-
-    async def request(
+    async def _request(
         self,
         method: str,
         endpoint: str,
@@ -103,3 +79,43 @@ class Client:  # pylint: disable=too-many-instance-attributes
                 raise RequestError(
                     f"Error requesting data from {endpoint}: {err}"
                 ) from None
+
+    async def async_init(self) -> None:
+        """Create a Tile session."""
+        if not self._client_established:
+            await self._request(
+                "put",
+                f"clients/{self.client_uuid}",
+                data={
+                    "app_id": DEFAULT_APP_ID,
+                    "app_version": DEFAULT_APP_VERSION,
+                    "locale": self._locale,
+                },
+            )
+            self._client_established = True
+
+        resp: dict = await self._request(
+            "post",
+            f"clients/{self.client_uuid}/sessions",
+            data={"email": self._email, "password": self._password},
+        )
+
+        if not self.user_uuid:
+            self.user_uuid = resp["result"]["user"]["user_uuid"]
+        self._session_expiry = resp["result"]["session_expiration_timestamp"]
+
+        self.tiles = Tile(self._request, user_uuid=self.user_uuid)
+
+
+async def login(
+    email: str,
+    password: str,
+    websession: ClientSession,
+    *,
+    client_uuid: Optional[UUID] = None,
+    locale: str = DEFAULT_LOCALE,
+) -> Client:
+    """Return an authenticated client."""
+    client = Client(email, password, websession, client_uuid=client_uuid, locale=locale)
+    await client.async_init()
+    return client

--- a/pytile/client.py
+++ b/pytile/client.py
@@ -107,7 +107,7 @@ class Client:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
         self.tiles = Tile(self._request, user_uuid=self.user_uuid)
 
 
-async def login(
+async def async_login(
     email: str,
     password: str,
     websession: ClientSession,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import aiohttp
 import pytest
 
-from pytile import login
+from pytile import async_login
 from pytile.errors import RequestError
 
 from .const import TILE_CLIENT_UUID, TILE_EMAIL, TILE_PASSWORD, TILE_USER_UUID
@@ -40,7 +40,7 @@ async def test_bad_endpoint(
 
     with pytest.raises(RequestError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
-            client = await login(
+            client = await async_login(
                 TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
             )
             await client._request("get", "bad_endpoint")
@@ -68,7 +68,7 @@ async def test_login(
     )
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = await login(TILE_EMAIL, TILE_PASSWORD, websession)
+        client = await async_login(TILE_EMAIL, TILE_PASSWORD, websession)
         assert isinstance(client.client_uuid, UUID)
         assert client.client_uuid != TILE_CLIENT_UUID
         assert client.user_uuid == TILE_USER_UUID
@@ -93,7 +93,7 @@ async def test_login_existing(
     )
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = await login(
+        client = await async_login(
             TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
         )
         assert client.client_uuid == TILE_CLIENT_UUID

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -6,7 +6,7 @@ import json
 import aiohttp
 import pytest
 
-from pytile import Client
+from pytile import login
 from pytile.errors import SessionExpiredError
 
 from .const import (
@@ -56,10 +56,9 @@ async def test_get_all(  # pylint: disable=too-many-arguments
     )
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = Client(
+        client = await login(
             TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
         )
-        await client.async_init()
         tiles = await client.tiles.all()
 
         assert tiles[0]["name"] == TILE_TILE_NAME
@@ -85,8 +84,7 @@ async def test_expired_session(
 
     with pytest.raises(SessionExpiredError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
-            client = Client(
+            client = await login(
                 TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
             )
-            await client.async_init()
             await client.tiles.all()

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -6,7 +6,7 @@ import json
 import aiohttp
 import pytest
 
-from pytile import login
+from pytile import async_login
 from pytile.errors import SessionExpiredError
 
 from .const import (
@@ -56,7 +56,7 @@ async def test_get_all(  # pylint: disable=too-many-arguments
     )
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
-        client = await login(
+        client = await async_login(
             TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
         )
         tiles = await client.tiles.all()
@@ -84,7 +84,7 @@ async def test_expired_session(
 
     with pytest.raises(SessionExpiredError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
-            client = await login(
+            client = await async_login(
                 TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
             )
             await client.tiles.all()


### PR DESCRIPTION
**Describe what the PR does:**

The current manner of creating a client is cumbersome: it requires the user to instantiate an object _and_ subsequently run an `async_init()` method. I don't like that. This PR consolidates everything into a single `async_login()` method.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
