### PR TITLE
Update default app ID to be latest iOS

### DIFF
--- a/example.py
+++ b/example.py
@@ -3,7 +3,7 @@ import asyncio
 
 from aiohttp import ClientSession
 
-from pytile import login
+from pytile import async_login
 from pytile.errors import TileError
 
 
@@ -12,7 +12,7 @@ async def main():
     async with ClientSession() as websession:
         try:
             # Create a client:
-            client = await login("<EMAIL>", "<PASSWORD>", websession)
+            client = await async_login("<EMAIL>", "<PASSWORD>", websession)
 
             print("Showing active Tiles:")
             print(await client.tiles.all())

--- a/pytile/client.py
+++ b/pytile/client.py
@@ -10,7 +10,7 @@ from .util import current_epoch_time
 
 API_URL_SCAFFOLD: str = "https://production.tile-api.com/api/v1"
 DEFAULT_APP_ID: str = "ios-tile-production"
-DEFAULT_APP_VERSION: str = "2.31.0"
+DEFAULT_APP_VERSION: str = "2.55.1.3707"
 DEFAULT_LOCALE: str = "en-US"
 
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR updates the default Tile app ID to be consistent with what the latest iOS app uses.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
