### PR TITLE
Store UUIDs as strings

### DIFF
--- a/pytile/client.py
+++ b/pytile/client.py
@@ -1,6 +1,6 @@
 """Define a client to interact with Pollen.com."""
 from typing import Optional
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from aiohttp import ClientSession, client_exceptions
 
@@ -23,7 +23,7 @@ class Client:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
         password: str,
         websession: ClientSession,
         *,
-        client_uuid: Optional[UUID] = None,
+        client_uuid: Optional[str] = None,
         locale: str = DEFAULT_LOCALE,
     ) -> None:
         """Initialize."""
@@ -34,11 +34,11 @@ class Client:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
         self._session_expiry: Optional[int] = None
         self._websession: ClientSession = websession
         self.tiles: Optional[Tile] = None
-        self.user_uuid: Optional[UUID] = None
+        self.user_uuid: Optional[str] = None
 
-        self.client_uuid: UUID
+        self.client_uuid: str
         if not client_uuid:
-            self.client_uuid = uuid4()
+            self.client_uuid = str(uuid4())
         else:
             self.client_uuid = client_uuid
 
@@ -61,7 +61,7 @@ class Client:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
             {
                 "Tile_app_id": DEFAULT_APP_ID,
                 "Tile_app_version": DEFAULT_APP_VERSION,
-                "Tile_client_uuid": str(self.client_uuid),
+                "Tile_client_uuid": self.client_uuid,
             }
         )
 
@@ -112,7 +112,7 @@ async def async_login(
     password: str,
     websession: ClientSession,
     *,
-    client_uuid: Optional[UUID] = None,
+    client_uuid: Optional[str] = None,
     locale: str = DEFAULT_LOCALE,
 ) -> Client:
     """Return an authenticated client."""

--- a/pytile/tile.py
+++ b/pytile/tile.py
@@ -1,6 +1,5 @@
 """Define endpoints for interacting with Tiles."""
 from typing import Awaitable, Callable, List, Optional
-from uuid import UUID
 
 
 class Tile:  # pylint: disable=too-few-public-methods
@@ -10,18 +9,18 @@ class Tile:  # pylint: disable=too-few-public-methods
         self,
         request: Callable[..., Awaitable[dict]],
         *,
-        user_uuid: Optional[UUID] = None,
+        user_uuid: Optional[str] = None,
     ) -> None:
         """Initialize."""
         self._request: Callable[..., Awaitable[dict]] = request
-        self._user_uuid: Optional[UUID] = user_uuid
+        self._user_uuid: Optional[str] = user_uuid
 
     async def all(self, whitelist: list = None, show_inactive: bool = False) -> list:
         """Get all Tiles for a user's account."""
         list_data: dict = await self._request(
             "get", f"users/{self._user_uuid}/user_tiles"
         )
-        tile_uuid_list: List[UUID] = [
+        tile_uuid_list: List[str] = [
             tile["tile_uuid"]
             for tile in list_data["result"]
             if not whitelist or tile["tileType"] in whitelist

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,6 @@
 # pylint: disable=redefined-outer-name,unused-import
 import json
 import re
-from uuid import UUID
 
 import aiohttp
 import pytest
@@ -69,7 +68,7 @@ async def test_login(
 
     async with aiohttp.ClientSession(loop=event_loop) as websession:
         client = await async_login(TILE_EMAIL, TILE_PASSWORD, websession)
-        assert isinstance(client.client_uuid, UUID)
+        assert isinstance(client.client_uuid, str)
         assert client.client_uuid != TILE_CLIENT_UUID
         assert client.user_uuid == TILE_USER_UUID
 


### PR DESCRIPTION
**Describe what the PR does:**

I originally wanted to store the client UUID as a `uuid.UUID` for correctness; however, in the case of Home Assistant (whose Tile integration saves the client UUID to a text file), an error occurs because that type can't be JSON-serialized (https://github.com/home-assistant/home-assistant/issues/28556).

So, in order to simplify this and to be more consistent with how the user UUID is stored, this PR stores the client UUID as a string.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
