### PR TITLE
Make aiohttp ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,48 +31,30 @@ pip install pytile
 
 # Usage
 
-`pytile` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
-
 ```python
 import asyncio
 
 from aiohttp import ClientSession
 
-from pytile import Client
+from pytile import async_login
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        # YOUR CODE HERE
+    """Run!"""
+    client = await async_login("<EMAIL>", "<PASSWORD>")
+
+    # Get all Tiles associated with an account:
+    await client.tiles.all()
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
-If you receive SSL errors, use `ClientSession(connector=TCPConnector(verify_ssl=False))`
-instead:
-
-```python
-import asyncio
-
-from aiohttp import ClientSession, TCPConnector
-
-from pytile import Client
-
-
-async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession(connector=TCPConnector(verify_ssl=False)) as websession:
-        # YOUR CODE HERE
-
-
-asyncio.get_event_loop().run_until_complete(main())
-```
-
-Create a client, initialize it, and get to work:
+By default, the library creates a new connection to Tile with each coroutine. If you are
+calling a large number of coroutines (or merely want to squeeze out every second of
+runtime savings possible), an
+[`aiohttp`](https://github.com/aio-libs/aiohttp) `ClientSession` can be used for connection
+pooling:
 
 ```python
 import asyncio
@@ -83,15 +65,15 @@ from pytile import async_login
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        client = await async_login("<EMAIL>", "<PASSWORD>", websession)
+    """Run!"""
+    async with ClientSession() as session:
+        client = await async_login("<EMAIL>", "<PASSWORD>", session)
 
         # Get all Tiles associated with an account:
         await client.tiles.all()
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
 If for some reason you need to use a specific client UUID (to, say, ensure that the
@@ -107,17 +89,16 @@ from pytile import async_login
 
 
 async def main() -> None:
-    """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        client = await async_login(
-            "<EMAIL>", "<PASSWORD>", websession, client_uuid="MY_UUID", locale="en-GB"
-        )
+    """Run!"""
+    client = await async_login(
+        "<EMAIL>", "<PASSWORD>", client_uuid="MY_UUID", locale="en-GB"
+    )
 
-        # Get all Tiles associated with an account:
-        await client.tiles.all()
+    # Get all Tiles associated with an account:
+    await client.tiles.all()
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())
 ```
 
 # Contributing
@@ -126,7 +107,7 @@ asyncio.get_event_loop().run_until_complete(main())
   or [initiate a discussion on one](https://github.com/bachya/pytile/issues/new).
 2. [Fork the repository](https://github.com/bachya/pytile/fork).
 3. (_optional, but highly recommended_) Create a virtual environment: `python3 -m venv .venv`
-4. (_optional, but highly recommended_) Enter the virtual environment: `source ./venv/bin/activate`
+4. (_optional, but highly recommended_) Enter the virtual environment: `source ./.venv/bin/activate`
 5. Install the dev environment: `script/setup`
 6. Code your new feature or bug fix.
 7. Write tests that cover your new functionality.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ location and more).
 This library is built on an unpublished, unofficial Tile API; it may alter or
 cease operation at any point.
 
+- [Python Versions](#python-versions)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Contributing](#contributing)
+
 # Python Versions
 
 `pytile` is currently supported on:

--- a/examples/test_api.py
+++ b/examples/test_api.py
@@ -9,10 +9,10 @@ from pytile.errors import TileError
 
 async def main():
     """Run."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         try:
             # Create a client:
-            client = await async_login("<EMAIL>", "<PASSWORD>", websession)
+            client = await async_login("<EMAIL>", "<PASSWORD>", session=session)
 
             print("Showing active Tiles:")
             print(await client.tiles.all())
@@ -23,4 +23,4 @@ async def main():
             print(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,6 @@ python = "^3.6.0"
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"
 pre-commit = "^2.0.1"
-pytest = "^5.3.5"
+pytest = "^5.4.1"
 pytest-aiohttp = "^0.3.0"
 pytest-cov = "^2.8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ aiohttp==3.6.2
 aresponses==1.1.2
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
-pytest==5.3.5
+pytest==5.4.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,9 +42,9 @@ async def test_bad_endpoint(aresponses, fixture_create_session):
     )
 
     with pytest.raises(RequestError):
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             client = await async_login(
-                TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
+                TILE_EMAIL, TILE_PASSWORD, client_uuid=TILE_CLIENT_UUID, session=session
             )
             await client._request("get", "bad_endpoint")
 
@@ -70,8 +70,8 @@ async def test_login(aresponses, fixture_create_session):
         aresponses.Response(text=json.dumps(fixture_create_session), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
-        client = await async_login(TILE_EMAIL, TILE_PASSWORD, websession)
+    async with aiohttp.ClientSession() as session:
+        client = await async_login(TILE_EMAIL, TILE_PASSWORD, session=session)
         assert isinstance(client.client_uuid, str)
         assert client.client_uuid != TILE_CLIENT_UUID
         assert client.user_uuid == TILE_USER_UUID
@@ -95,8 +95,8 @@ async def test_login_existing(aresponses, fixture_create_session):
         aresponses.Response(text=json.dumps(fixture_create_session), status=200),
     )
 
-    async with aiohttp.ClientSession() as websession:
+    async with aiohttp.ClientSession() as session:
         client = await async_login(
-            TILE_EMAIL, TILE_PASSWORD, websession, client_uuid=TILE_CLIENT_UUID
+            TILE_EMAIL, TILE_PASSWORD, client_uuid=TILE_CLIENT_UUID, session=session
         )
         assert client.client_uuid == TILE_CLIENT_UUID


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes the `aiohttp` `ClientSession` an optional parameter when creating an API object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
