### PR TITLE
Change client.tiles.all() to return dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.6.2"
 python = "^3.6.0"
+pylint = "^2.5.2"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^2.0.0"

--- a/pytile/tile.py
+++ b/pytile/tile.py
@@ -1,5 +1,5 @@
 """Define endpoints for interacting with Tiles."""
-from typing import Awaitable, Callable, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 
 
 class Tile:  # pylint: disable=too-few-public-methods
@@ -15,11 +15,14 @@ class Tile:  # pylint: disable=too-few-public-methods
         self._request: Callable[..., Awaitable[dict]] = request
         self._user_uuid: Optional[str] = user_uuid
 
-    async def all(self, whitelist: list = None, show_inactive: bool = False) -> list:
+    async def all(
+        self, whitelist: list = None, show_inactive: bool = False
+    ) -> Dict[str, dict]:
         """Get all Tiles for a user's account."""
         list_data: dict = await self._request(
             "get", f"users/{self._user_uuid}/user_tiles"
         )
+
         tile_uuid_list: List[str] = [
             tile["tile_uuid"]
             for tile in list_data["result"]
@@ -29,8 +32,9 @@ class Tile:  # pylint: disable=too-few-public-methods
         tile_data: dict = await self._request(
             "get", "tiles", params=[("tile_uuids", uuid) for uuid in tile_uuid_list]
         )
-        return [
-            tile
-            for tile in tile_data["result"].values()
+
+        return {
+            tile_uuid: tile
+            for tile_uuid, tile in tile_data["result"].items()
             if show_inactive or tile["visible"] is True
-        ]
+        }

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -12,6 +12,7 @@ from .common import (
     TILE_EMAIL,
     TILE_PASSWORD,
     TILE_TILE_NAME,
+    TILE_TILE_UUID,
     TILE_USER_UUID,
     load_fixture,
 )
@@ -82,7 +83,8 @@ async def test_get_all(
             TILE_EMAIL, TILE_PASSWORD, client_uuid=TILE_CLIENT_UUID, session=session
         )
         tiles = await client.tiles.all()
-        assert tiles[0]["name"] == TILE_TILE_NAME
+        assert len(tiles) == 1
+        assert tiles[TILE_TILE_UUID]["name"] == TILE_TILE_NAME
 
 
 @pytest.mark.asyncio
@@ -121,4 +123,5 @@ async def test_get_all_no_explicit_session(
 
     client = await async_login(TILE_EMAIL, TILE_PASSWORD, client_uuid=TILE_CLIENT_UUID)
     tiles = await client.tiles.all()
-    assert tiles[0]["name"] == TILE_TILE_NAME
+    assert len(tiles) == 1
+    assert tiles[TILE_TILE_UUID]["name"] == TILE_TILE_NAME


### PR DESCRIPTION
**Describe what the PR does:**

This PR alters the return value of `client.tiles.all()` to be a `dict` (with the Tile's UUID as the key) for easier lookup.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
