### PR TITLE
Fix bug where re-initialization would fail

### DIFF
--- a/pytile/client.py
+++ b/pytile/client.py
@@ -39,10 +39,7 @@ class Client:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
         self.user_uuid: Optional[str] = None
 
         self.client_uuid: str
-        if not client_uuid:
-            self.client_uuid = str(uuid4())
-        else:
-            self.client_uuid = client_uuid
+        self.client_uuid = str(uuid4()) if not client_uuid else client_uuid
 
     async def _request(
         self,

--- a/pytile/client.py
+++ b/pytile/client.py
@@ -93,6 +93,10 @@ class Client:  # pylint: disable=too-few-public-methods,too-many-instance-attrib
 
     async def async_init(self) -> None:
         """Create a Tile session."""
+        # Invalidate the existing session expiry datetime (if it exists) so that the
+        # next few requests don't fail:
+        self._session_expiry = None
+
         if not self._client_established:
             await self._request(
                 "put",


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes a bug wherein client requests would _always_ throw a `SessionExpiredError`, even when attempting to create a new session.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
