### PR TITLE
Add ring_state and voip_state properties to Tile

### DIFF
--- a/pytile/tile.py
+++ b/pytile/tile.py
@@ -118,6 +118,11 @@ class Tile:
         return self._tile_data["name"]
 
     @property
+    def ring_state(self) -> str:
+        """Return the ring state."""
+        return self._tile_data["last_tile_state"]["ring_state"]
+
+    @property
     def uuid(self) -> str:
         """Return the UUID."""
         return self._tile_data["tile_uuid"]
@@ -126,6 +131,11 @@ class Tile:
     def visible(self) -> bool:
         """Return whether the Tile is visible."""
         return self._tile_data["visible"]
+
+    @property
+    def voip_state(self) -> str:
+        """Return the VoIP state."""
+        return self._tile_data["last_tile_state"]["voip_state"]
 
     def _async_save_new_data(self, data: dict) -> None:
         """Save new Tile data in this object."""

--- a/tests/test_tile.py
+++ b/tests/test_tile.py
@@ -75,17 +75,19 @@ async def test_get_tiles(aresponses, create_session_response):
         assert tile.altitude == 0.4076319168123
         assert tile.archetype == "WALLET"
         assert not tile.dead
+        assert not tile.lost
         assert tile.firmware_version == "01.12.14.0"
         assert tile.hardware_version == "02.09"
         assert tile.kind == "TILE"
         assert tile.last_timestamp == datetime(2020, 8, 12, 17, 55, 26)
         assert tile.latitude == 51.528308
         assert tile.longitude == -0.3817765
-        assert not tile.lost
         assert tile.lost_timestamp == datetime(1969, 12, 31, 23, 59, 59, 999000)
         assert tile.name == TILE_TILE_NAME
+        assert tile.ring_state == "STOPPED"
         assert tile.uuid == TILE_TILE_UUID
         assert tile.visible
+        assert tile.voip_state == "OFFLINE"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds `ring_state`  and `voip_state` properties to the `Tile` object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
