### PR TITLE
 Change the coverage badge to track the `dev` branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,8 +11,8 @@ categories:
       - "bug"
   - title: "🧰 Maintenance"
     labels:
-      - "ci/cd"
       - "dependencies"
+      - "documentation"
       - "maintenance"
       - "tooling"
 change-template: "- $TITLE (#$NUMBER)"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPi](https://img.shields.io/pypi/v/pytile.svg)](https://pypi.python.org/pypi/pytile)
 [![Version](https://img.shields.io/pypi/pyversions/pytile.svg)](https://pypi.python.org/pypi/pytile)
 [![License](https://img.shields.io/pypi/l/pytile.svg)](https://github.com/bachya/pytile/blob/main/LICENSE)
-[![Code Coverage](https://codecov.io/gh/bachya/pytile/branch/main/graph/badge.svg)](https://codecov.io/gh/bachya/pytile)
+[![Code Coverage](https://codecov.io/gh/bachya/pytile/branch/dev/graph/badge.svg)](https://codecov.io/gh/bachya/pytile)
 [![Maintainability](https://api.codeclimate.com/v1/badges/71eb642c735e33adcdfc/maintainability)](https://codeclimate.com/github/bachya/pytile/maintainability)
 [![Say Thanks](https://img.shields.io/badge/SayThanks-!-1EAEDB.svg)](https://saythanks.io/to/bachya)
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR adjusts the code coverage badge to track the `dev` branch (and not `main`).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
