### PR TITLE
Add endpoint to get a premium Tile's history

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ asyncio.run(main())
 
 ## Getting Tiles
 
+**Tile Premium Required: No**
+
 ```python
 import asyncio
 
@@ -180,7 +182,9 @@ asyncio.run(main())
 
 ## Getting Premium Tile's History
 
-You can retrieve a premium Tile's history by calling its `async_history` coroutine:
+**Tile Premium Required: Yes**
+
+You can retrieve a Tile's history by calling its `async_history` coroutine:
 
 ```python
 import asyncio

--- a/README.md
+++ b/README.md
@@ -178,6 +178,37 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
+## Getting Tile History
+
+You can retrieve a Tile's history by calling its `async_history` coroutine:
+
+```python
+import asyncio
+from datetime import datetime
+
+from aiohttp import ClientSession
+
+from pytile import async_login
+
+
+async def main() -> None:
+    """Run!"""
+    async with ClientSession() as session:
+        api = await async_login("<EMAIL>", "<PASSWORD>", session)
+
+        tiles = await api.async_get_tiles()
+
+        for tile_uuid, tile in tiles.items():
+            # Define a start and end datetime to get history for:
+            start = datetime(2023, 1, 1, 0, 0, 0)
+            end = datetime(2023, 1, 31, 0, 0, 0)
+            history = tile.async_history(start, end)
+            # >>> { "version": 1, "revision": 1, ... }
+
+
+asyncio.run(main())
+```
+
 # Contributing
 
 Thanks to all of [our contributors][contributors] so far!

--- a/README.md
+++ b/README.md
@@ -178,9 +178,9 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-## Getting Tile History
+## Getting Premium Tile's History
 
-You can retrieve a Tile's history by calling its `async_history` coroutine:
+You can retrieve a premium Tile's history by calling its `async_history` coroutine:
 
 ```python
 import asyncio

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ async def main() -> None:
             # Define a start and end datetime to get history for:
             start = datetime(2023, 1, 1, 0, 0, 0)
             end = datetime(2023, 1, 31, 0, 0, 0)
-            history = tile.async_history(start, end)
+            history = await tile.async_history(start, end)
             # >>> { "version": 1, "revision": 1, ... }
 
 

--- a/pytile/tile.py
+++ b/pytile/tile.py
@@ -250,6 +250,24 @@ class Tile:
             "voip_state": self.voip_state,
         }
 
+    async def async_history(
+        self, start_datetime: datetime, end_datetime: datetime
+    ) -> dict[str, Any]:
+        """Get the latest measurements from the Tile.
+
+        Returns:
+            A dictionary containing the requested history.
+        """
+        return await self._async_request(
+            "get",
+            f"tiles/location/history/{self.uuid}",
+            params={
+                "aggregation": "False",
+                "end_ts": round(end_datetime.timestamp() * 1000),
+                "start_ts": round(start_datetime.timestamp() * 1000),
+            },
+        )
+
     async def async_update(self) -> None:
         """Get the latest measurements from the Tile."""
         data = await self._async_request("get", f"tiles/{self.uuid}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,12 @@ def tile_details_update_response_fixture() -> dict[str, Any]:
     return cast(dict[str, Any], data)
 
 
+@pytest.fixture(name="tile_history_response", scope="session")
+def tile_history_response_fixture() -> dict[str, Any]:
+    """Return a fixture for a Tile history response."""
+    return cast(dict[str, Any], json.loads(load_fixture("tile_history_response.json")))
+
+
 @pytest.fixture(name="tile_states_response", scope="session")
 def tile_states_response_fixture() -> dict[str, Any]:
     """Return a fixture for a Tile states response."""

--- a/tests/fixtures/tile_history_response.json
+++ b/tests/fixtures/tile_history_response.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "revision": 1,
+  "timestamp": "2023-04-10T17:49:50.098Z",
+  "timestamp_ms": 1681148990098,
+  "result_code": 0,
+  "result": {
+    "complete_history": "Y",
+    "location_updates": []
+  }
+}


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds an endpoint to get a Tile's history (between a start and end datetime)—note that this requires Tile Premium.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pytile/issues/117

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.
