### PR TITLE
Replace datetime.utcfromtimestamp

### DIFF
--- a/pytile/tile.py
+++ b/pytile/tile.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, cast
 
 from .const import LOGGER
@@ -219,10 +219,12 @@ class Tile:
             self._lost_timestamp = None
             return
 
-        self._last_timestamp = datetime.utcfromtimestamp(last_state["timestamp"] / 1000)
-        self._lost_timestamp = datetime.utcfromtimestamp(
-            last_state["lost_timestamp"] / 1000
-        )
+        self._last_timestamp = datetime.fromtimestamp(
+            last_state["timestamp"] / 1000, tz=timezone.utc
+        ).replace(tzinfo=None)
+        self._lost_timestamp = datetime.fromtimestamp(
+            last_state["lost_timestamp"] / 1000, tz=timezone.utc
+        ).replace(tzinfo=None)
 
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this Tile.


### PR DESCRIPTION
**Describe what the PR does:**
Starting with Python 3.12 `datetime.utcfromtimestamp` will be deprecated.
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp